### PR TITLE
Bug fix: script thinks player is still open after it closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 ### Supported Players
 
 - [Spotify](https://www.spotify.com/)
+- [VLC](https://www.videolan.org/)
 - [cmus](https://cmus.github.io/)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">Now Clocking</h1>
-<p align="center"><i>Made with :heart: by <a href="https://github.com/gamehelp16">@gamehelp16</a> and <a href="https://github.com/Rayzr522">@Rayzr522</a></i></p>
+<p align="center"><i>Made with :heart: by <a href="https://github.com/gamehelp16">@gamehelp16</a>, <a href="https://github.com/Rayzr522">@Rayzr522</a> and <a href="https://github.com/jgabriel98">@jgabriel98</a></i></p>
 
 > **Now Clocking** is a Conky widget which shows a Monstercat style Now Playing when music is played via Spotify or cmus, or a clock when no music is playing.
 
@@ -72,13 +72,3 @@ $ path/to/now-clocking/start.sh
 > **Why are there 2 Conky widgets?**
 
 Originally, this had to do with weird transparency issues in Conky that required a non-transparent album artwork. However, that has long since been patched in Conky. The widgets have remained separated, however, so as to make aligning everything easier, especially since one widget functions both as the track info *and* a clock.
-
-## Credits
-
-Huge props to the original creator, [@gamehelp16](https://github.com/gamehelp16). I used this script back in 2017/2018 and rediscovered it in 2020, and decided to rework it to be more portable, efficient, and updated to modern Conky config standards.
-
-Also huge props to Hoefler & Frere-Jones for the wonderful Gotham fonts, and Julieta Ulanovsky (and crew) for the slick Montserrat font.
-
-## Join Me
-
-[![Discord Badge](https://github.com/Rayzr522/ProjectResources/raw/master/RayzrDev/badge-small.png)](https://rayzr.dev/join)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@
   - [Supported Players](#supported-players)
 - [Installation](#installation)
 - [FAQ](#faq)
-- [Credits](#credits)
-- [Join Me](#join-me)
 
 ## Requirements
 

--- a/conky/np.lua
+++ b/conky/np.lua
@@ -33,14 +33,19 @@ conky.config = {
 conky.text = [[
 ${if_running spotify}${color #fff}${font Gotham Book:pixelsize=18}NOW PLAYING:
 ${color #fff}${font Gotham Book:pixelsize=15}
-
 ${color #fff}${font Gotham:style=bold:pixelsize=44}           ${font Gotham:style=bold:pixelsize=46}${exec playerctl -p spotify metadata artist}${font Gotham:style=bold:pixelsize=10}
 ${color #fff}${font Gotham Book:pixelsize=44}           ${font Gotham Book:pixelsize=23}${exec playerctl -p spotify metadata title}
+
+${else}${if_match "" != "${exec playerctl -p vlc status}"}${color #fff}${font Gotham Book:pixelsize=18}NOW PLAYING:
+${color #fff}${font Gotham Book:pixelsize=15}
+${color #fff}${font Gotham:style=bold:pixelsize=44}           ${font Gotham:style=bold:pixelsize=46}${exec playerctl -p vlc metadata artist}${font Gotham:style=bold:pixelsize=10}
+${color #fff}${font Gotham Book:pixelsize=44}           ${font Gotham Book:pixelsize=23}${exec playerctl -p vlc metadata title}
+
 ${else}${if_running cmus}${color #fff}${font Gotham Book:pixelsize=18}NOW PLAYING:
 ${color #fff}${font Gotham Book:pixelsize=15}
-
 ${color #fff}${font Gotham:style=bold:pixelsize=44}           ${font Gotham:style=bold:pixelsize=46}${exec cmus-remote -Q 2>/dev/null | grep 'tag artist' | cut -d " " -f 3-}${font Gotham:style=bold:pixelsize=10}
 ${color #fff}${font Gotham:style=bold:pixelsize=44}           ${font Gotham Book:pixelsize=23}${exec cmus-remote -Q 2>/dev/null | grep title | cut -d " " -f 3- }
+
 ${else}${color #fff}${font Gotham Book:pixelsize=80}${time %H:%M:%S}${font Gotham Book:pixelsize=65}
-${color #fff}${font Montserrat Light:pixelsize=35}${time %B} ${time %d}${if_match ${time %d}==1}st${else}${if_match ${time %d}==2}nd${else}${if_match ${time %d}==3}rd${else}${if_match ${time %d}==4}th${else}${if_match ${time %d}==5}th${else}${if_match ${time %d}==5}th${else}${if_match ${time %d}==7}th${else}${if_match ${time %d}==8}th${else}${if_match ${time %d}==9}th${else}${if_match ${time %d}==10}th${else}${if_match ${time %d}==11}th${else}${if_match ${time %d}==12}th${else}${if_match ${time %d}==13}th${else}${if_match ${time %d}==14}th${else}${if_match ${time %d}==15}th${else}${if_match ${time %d}==16}th${else}${if_match ${time %d}==17}th${else}${if_match ${time %d}==18}th${else}${if_match ${time %d}==19}th${else}${if_match ${time %d}==20}th${else}${if_match ${time %d}==21}st${else}${if_match ${time %d}==22}nd${else}${if_match ${time %d}==23}rd${else}${if_match ${time %d}==24}th${else}${if_match ${time %d}==25}th${else}${if_match ${time %d}==26}th${else}${if_match ${time %d}==27}th${else}${if_match ${time %d}==28}th${else}${if_match ${time %d}==29}th${else}${if_match ${time %d}==30}th${else}${if_match ${time %d}==31}st${else}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif} ${time %Y}${endif}${endif}
+${color #fff}${font Montserrat Light:pixelsize=35}${time %B} ${time %d}${if_match ${time %d}==1}st${else}${if_match ${time %d}==2}nd${else}${if_match ${time %d}==3}rd${else}${if_match ${time %d}==4}th${else}${if_match ${time %d}==5}th${else}${if_match ${time %d}==5}th${else}${if_match ${time %d}==7}th${else}${if_match ${time %d}==8}th${else}${if_match ${time %d}==9}th${else}${if_match ${time %d}==10}th${else}${if_match ${time %d}==11}th${else}${if_match ${time %d}==12}th${else}${if_match ${time %d}==13}th${else}${if_match ${time %d}==14}th${else}${if_match ${time %d}==15}th${else}${if_match ${time %d}==16}th${else}${if_match ${time %d}==17}th${else}${if_match ${time %d}==18}th${else}${if_match ${time %d}==19}th${else}${if_match ${time %d}==20}th${else}${if_match ${time %d}==21}st${else}${if_match ${time %d}==22}nd${else}${if_match ${time %d}==23}rd${else}${if_match ${time %d}==24}th${else}${if_match ${time %d}==25}th${else}${if_match ${time %d}==26}th${else}${if_match ${time %d}==27}th${else}${if_match ${time %d}==28}th${else}${if_match ${time %d}==29}th${else}${if_match ${time %d}==30}th${else}${if_match ${time %d}==31}st${else}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif}${endif} ${time %Y}${endif}${endif}${endif}
 ]];

--- a/conky/np.lua
+++ b/conky/np.lua
@@ -31,7 +31,7 @@ conky.config = {
 };
 
 conky.text = [[
-${if_running spotify}${color #fff}${font Gotham Book:pixelsize=18}NOW PLAYING:
+${if_match "" != "${exec playerctl -p spotify status}}${color #fff}${font Gotham Book:pixelsize=18}NOW PLAYING:
 ${color #fff}${font Gotham Book:pixelsize=15}
 ${color #fff}${font Gotham:style=bold:pixelsize=44}           ${font Gotham:style=bold:pixelsize=46}${exec playerctl -p spotify metadata artist}${font Gotham:style=bold:pixelsize=10}
 ${color #fff}${font Gotham Book:pixelsize=44}           ${font Gotham Book:pixelsize=23}${exec playerctl -p spotify metadata title}

--- a/conky/npart.lua
+++ b/conky/npart.lua
@@ -27,10 +27,12 @@ conky.config = {
 
 conky.text = [[
 ${if_running spotify}${exec ./scripts/fetch-art spotify}
-${image ./data/spotify.png -p 0,0 -s 125x125 -n}
+	${image ./data/spotify.png -p 0,0 -s 125x125 -n}
+${else}${if_match "" != "${exec playerctl -p vlc status}"}${exec ./scripts/fetch-art vlc}
+	${image ./data/vlc.png -p 0,0 -s 125x125 -n}
+${else}${if_running cmus}${exec ./scripts/fetch-art cmus}
+	${image ./data/cmus.png -p 0,0 -s 125x125 -n}
 ${endif}
-
-${if_running cmus}${exec ./scripts/fetch-art cmus}
-${image ./data/cmus.png -p 0,0 -s 125x125 -n}
+${endif}
 ${endif}
 ]];

--- a/conky/npart.lua
+++ b/conky/npart.lua
@@ -26,7 +26,7 @@ conky.config = {
 };
 
 conky.text = [[
-${if_running spotify}${exec ./scripts/fetch-art spotify}
+${if_match "" != "${exec playerctl -p spotify status}}${exec ./scripts/fetch-art spotify}
 	${image ./data/spotify.png -p 0,0 -s 125x125 -n}
 ${else}${if_match "" != "${exec playerctl -p vlc status}"}${exec ./scripts/fetch-art vlc}
 	${image ./data/vlc.png -p 0,0 -s 125x125 -n}

--- a/scripts/fetch-art
+++ b/scripts/fetch-art
@@ -21,9 +21,16 @@ if [ "$source" = spotify ]; then
     fi
 
     url="$(playerctl -p spotify metadata mpris:artUrl | sed 's;https://open.spotify.com;http://i.scdn.co;g')"
+elif [ "$source" = vlc ]; then
+    if ! command -v playerctl >/dev/null; then
+        echo "Missing playerctl!"
+        exit 1
+    fi
+
+    url="$(playerctl -p vlc metadata mpris:artUrl)"
 elif [ "$source" = cmus ]; then
-    if ! command -v cmus-remote >/dev/null; then
-        echo "Missing cmus-remote!"
+    if ! command -v ffmpeg >/dev/null; then
+        echo "Missing ffmpeg!"
         exit 1
     fi
 

--- a/scripts/fetch-art
+++ b/scripts/fetch-art
@@ -29,8 +29,8 @@ elif [ "$source" = vlc ]; then
 
     url="$(playerctl -p vlc metadata mpris:artUrl)"
 elif [ "$source" = cmus ]; then
-    if ! command -v ffmpeg >/dev/null; then
-        echo "Missing ffmpeg!"
+    if ! command -v cmus-remote >/dev/null; then
+        echo "Missing cmus-remote!"
         exit 1
     fi
 


### PR DESCRIPTION
The script used this command to detect if the spotify player was running:

${if_running spotify} ...stuff here...

**What this command really do**: it looks for a process that matches the given name (in this case, 'spotify').

But **the problem is**: some players have multiple process, and some of those always keep running, as a background task (i guess). And that is the case with spotify.

So, this lead us to **the bug**:
after closing the player, one process remain running. So the script thinks the player is running (but it's not).
![nowClocking_bug](https://user-images.githubusercontent.com/37881981/95019517-3ad87200-063c-11eb-8493-34b53b4e6091.gif)


## Solution
changed `${if_running spotify}` to `${if_match "" != "${exec playerctl -p spotify status}}`, 
so now it will **really** check for the player status, not for the player process.